### PR TITLE
Add release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*' # Trigger on tags that start with 'v'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Run distribute.py
+      run: |
+        python distribute.py
+      working-directory: ${{ github.workspace }}
+
+    - name: Create Release
+      id: create_release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: uv_dilation_checker.zip
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Show Release URL
+      run: |
+        echo "Release URL: ${{ steps.create_release.outputs.upload_url }}"


### PR DESCRIPTION
Added a github action to generate a release automatically on pushes with tagged commits.

For e.g. to tag a commit, replace the version and commit hash accordingly:
```bash
git tag -a v1.0.0 b21f0a
```
To push tags:
```bash
git push --tags
```