### PR TITLE
Improve performance

### DIFF
--- a/uv_dilation_checker.py
+++ b/uv_dilation_checker.py
@@ -13,9 +13,6 @@ from bpy.props import EnumProperty, IntProperty
 import tempfile
 import os
 import sys
-import time
-
-
 
 sys.path.append(os.path.dirname(__file__))
 

--- a/uv_dilation_checker.py
+++ b/uv_dilation_checker.py
@@ -88,19 +88,13 @@ def generator(resolution, strokesize):
         strokedimage[:, :, c] = strokecolor[c]
 
     result = cv2.add(image1, strokedimage)
-
-    time_start = time.perf_counter()
-    #cv2.imwrite(filepath, result)
-
-    #image2 = cv2.imread(filepath, cv2.IMREAD_UNCHANGED)
     
     mask = (result[:, :, 3] == 0)
     result[mask] = [255, 255, 255, 255]
     cv2.imwrite(filepath, result)
 
     bpy.ops.image.open(filepath=filepath, directory=tmpdir, files=[{"name":imagename}], relative_path=True, show_multiview=False)
-    
-    print(f'Took {time.perf_counter() - time_start:.3f} seconds')
+
     image = bpy.data.images[imagename]
 
     uveditorfound = False

--- a/uv_dilation_checker.py
+++ b/uv_dilation_checker.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "UV Dilation Checker",
     "author": "Sayan Sikdar",
-    "version": (1, 0),
+    "version": (1, 1),
     "blender": (2, 80, 0),
     "description": "check diation for uv",
     "category": "UV"


### PR DESCRIPTION
Remove unnecessary image copying and reopening.
Improves performance by roughly 2x